### PR TITLE
Set layer shadow position to fixed so it works properly when scrolled down

### DIFF
--- a/frontend/src/sass/buildStepOutput.sass
+++ b/frontend/src/sass/buildStepOutput.sass
@@ -42,7 +42,7 @@
   color: $white
 
 .layerShadow
-  position: absolute
+  position: fixed
   width: 100%
   height: 100%
   top: 0


### PR DESCRIPTION
Previously, it didn't look right when you
- Expanded multiple pipeline runs and
- Scrolled about one screen height or more down,

Because the shadow was displayed to far up.
