### PR TITLE
Change output icon to a text file icon for better user experience

### DIFF
--- a/frontend/src/js/main/steps/Tools.es6
+++ b/frontend/src/js/main/steps/Tools.es6
@@ -11,7 +11,7 @@ import LamdbdaUI from "../App.es6";
 import * as Utils from "../Utils.es6";
 import {KILLED_ICON} from "../StateIcon.es6";
 
-export const SHOW_OUTPUT_ICON_CLASS = "fa-align-justify";
+export const SHOW_OUTPUT_ICON_CLASS = "fa-file-text-o";
 export const SHOW_SUBSTEP_ICON_CLASS = "fa-level-down";
 export const SHOW_INTERESTING_STEP_ICON_CLASS = "fa-arrow-circle-down";
 export const RETRIGGER_STEP_ICON_CLASS = " fa-repeat";

--- a/frontend/src/js/test/steps/Tools.test.es6
+++ b/frontend/src/js/test/steps/Tools.test.es6
@@ -60,7 +60,7 @@ describe("Tools", () => {
 
     describe("Tools Icons", () => {
         it("should get iconClass for Output Tool", () => {
-            expect(SHOW_OUTPUT_ICON_CLASS).toEqual("fa-align-justify");
+            expect(SHOW_OUTPUT_ICON_CLASS).toEqual("fa-file-text-o");
         });
 
         it("should get iconClass for Substep Tool", () => {


### PR DESCRIPTION
Its easier to expect the output hidden behind the file icon instead of a text alignment icon