### PR TITLE
Use different mouse cursor icon to indicate the drag capabilities of …

### DIFF
--- a/frontend/src/html/design/css/styles.css
+++ b/frontend/src/html/design/css/styles.css
@@ -316,3 +316,16 @@ body{
 	padding: 8px;
 	background-color: #FFF;
 }
+
+.draggable {
+	cursor: move; /* fallback if grab cursor is unsupported */
+	cursor: grab;
+	cursor: -moz-grab;
+	cursor: -webkit-grab;
+}
+
+.draggable:active {
+	cursor: grabbing;
+	cursor: -moz-grabbing;
+	cursor: -webkit-grabbing;
+}

--- a/frontend/src/js/main/details/BuildDetails.es6
+++ b/frontend/src/js/main/details/BuildDetails.es6
@@ -52,7 +52,7 @@ export class BuildDetails extends React.Component {
 
         return <div className="BuildDetails" id={"draggable" + buildId}>
             {quickDetails}
-            <div className="BuildDetailSteps">
+            <div className="BuildDetailSteps draggable">
                 {R.map(step => <BuildStep key={step.stepId} step={step} buildId={buildId}/>)(stepsToDisplay)}
             </div>
         </div>;


### PR DESCRIPTION
…the build steps

This could be especially usefull as I first didn't know you could actually move the build steps, which is pretty handy if the sub steps grow larger than the available display space!