### PR TITLE
Require GPG only for deploying to clojars to avoid queries to unlock gpg in normal development

### DIFF
--- a/backend/project.clj
+++ b/backend/project.clj
@@ -12,12 +12,12 @@
                  [trptcolin/versioneer "0.2.0"]]
 
   :test-paths ["test"]
-  :repositories [["snapshots" { :url "https://clojars.org/repo"
-                                :username [:gpg :env]
-                                :password [:gpg :env]}]
-                 ["releases" { :url "https://clojars.org/repo"
-                                               :username [:gpg :env]
-                                               :password [:gpg :env]}]]
+  :deploy-repositories [["snapshots" {:url "https://clojars.org/repo"
+                                      :username [:gpg :env]
+                                      :password [:gpg :env]}]
+                        ["releases" {:url "https://clojars.org/repo"
+                                     :username [:gpg :env]
+                                     :password [:gpg :env]}]]
   :lein-release {:scm :git}
   :profiles {:dev {:dependencies [[lambdacd-git "0.1.2"]
                                   [com.gearswithingears/shrubbery "0.4.1"]


### PR DESCRIPTION
At the moment, whenever I'm doing something involving Leiningen, I get asked for my GPG passphrase to decrypt clojars credentials (that I don't even have). 

This changes the configuration to use use credentials only when actually deploying to Clojars (the last part is untested as I don't have permissions to deploy to your clojars repo :))