### PR TITLE
Make Lambda UI compatible with LambdaCD 0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+#### Fixed
+
+- Compatibility with LambdaCD 0.13.0
+
+#### Changed
+
+- Lambda UI now requires at least LambdaCD 0.10.0
+
 ## [0.3.3]
 
 #### Fixed

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Do you have more ideas or feedback?
 Open a [feature request](https://github.com/sroidl/lambda-ui/issues/new)!
 
 ## Usage
-As this project is only the User Interface, you'll need running [LambdaCD](https://github.com/flosell/lambdacd) pipeline. The minimum required version of LambdaCD is currently `0.9.0`. To use LambdaUI, you'll also need to use the [http-kit](http://www.http-kit.org/) (we tested it with v2.1.18) webserver to serve the backend of the UI.
+As this project is only the User Interface, you'll need running [LambdaCD](https://github.com/flosell/lambdacd) pipeline. The minimum required version of LambdaCD is currently `0.10.0`. To use LambdaUI, you'll also need to use the [http-kit](http://www.http-kit.org/) (we tested it with v2.1.18) webserver to serve the backend of the UI.
 
 ### Step-by-Step setup
 We'll suppose you've setup your pipeline as in the [example by LambdaCD](http://www.lambda.cd/getting-started/)

--- a/backend/project.clj
+++ b/backend/project.clj
@@ -4,7 +4,7 @@
   :license {:name "Apache License 2.0"
             :url  "http://www.apache.org/licenses/LICENSE-2.0"}
   :dependencies [[org.clojure/clojure "1.7.0"]
-                 [lambdacd "0.9.3"]
+                 [lambdacd "0.10.0"]
                  [compojure "1.5.0"]
                  [http-kit "2.2.0"]
                  [org.clojure/data.json "0.2.6"]
@@ -19,7 +19,7 @@
                                                :username [:gpg :env]
                                                :password [:gpg :env]}]]
   :lein-release {:scm :git}
-  :profiles {:dev {:dependencies [[lambdacd-git "0.1.2"]
+  :profiles {:dev {:dependencies [[lambdacd-git "0.2.0"]
                                   [com.gearswithingears/shrubbery "0.4.1"]
                                   [ring-cors "0.1.8"]
                                   [lambdacd-artifacts "0.2.1"]]

--- a/backend/src/lambdaui/trigger.clj
+++ b/backend/src/lambdaui/trigger.clj
@@ -1,6 +1,6 @@
 (ns lambdaui.trigger
   (:require [clojure.core.async :as async]
-            [lambdacd.internal.execution :as execution]
+            [lambdacd.execution :as execution]
             [clojure.walk :refer [keywordize-keys]]))
 
 

--- a/backend/test/lambdaui/testpipeline/core.clj
+++ b/backend/test/lambdaui/testpipeline/core.clj
@@ -9,7 +9,6 @@
             [lambdaui.testpipeline.long-running :as long-running-pipe]
             [lambdaui.testpipeline.artifact-pipeline :as artifact-pipeline]
             [lambdaui.core :as ui]
-            [lambdacd.internal.execution :as exec]
             [clojure.core.async :as async :refer [go <! <!! >! >!!]]
             [lambdacd.event-bus :as events]
             [lambdacd.event-bus :as event-bus]


### PR DESCRIPTION
LambdaCD 0.13.0 removes `lambdacd.internal.execution` on which `lambdaui.trigger` depends (to call `execution/run`).
This PR changes the call to `lambdacd.execution/run` (which is the same thing) instead. 

Compatibility notes: 
* `lambdacd.execution/run` requires at least `0.10.0` so this PR would change the minimum required Version of LambdaCD
* `lambdacd.execution/run` itself has been deprecated in favor of `lambdacd.execution.core/run-pipeline` in `0.13.0` but I didn't want to force Lambda UI users into the most recent version right now. However, this should be fixed once you are ready to go to `0.13.0` as the minimum version of LambdaCD