### PR TITLE
Rename public-resource directory to avoid clash in classpath

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -2,4 +2,5 @@
 .nrepl-port
 target
 resources/public
+resources/public-lambdaui
 tmp

--- a/backend/src/lambdaui/core.clj
+++ b/backend/src/lambdaui/core.clj
@@ -24,7 +24,7 @@
      (ring-json/wrap-json-response
        (wrap-params
          (routes
-           (route/resources "/lambdaui" {:root "public"})
+           (route/resources "/lambdaui" {:root "public-lambdaui"})
            (route/resources "/" {:root "public"})
            (GET "/lambdaui" [] (ring.util.response/redirect "lambdaui/index.html"))
            (GET "/lambdaui/config.js" [] (config/config_edn->config_js configuration))

--- a/go
+++ b/go
@@ -62,7 +62,7 @@ goal_setup() {
 goal_clean() {
   pushd ${SCRIPT_DIR}/backend > /dev/null
   ./lein clean
-  rm -rf resources/public
+  rm -rf resources/public-lambdaui
   popd > /dev/null
   pushd ${SCRIPT_DIR}/frontend > /dev/null
     npm run clean
@@ -74,14 +74,14 @@ goal_jar() {
   pushd ${SCRIPT_DIR}/frontend > /dev/null
    npm run compile
   popd > /dev/null
-  if [ ! -e ${SCRIPT_DIR}/backend/resources/public ]; then
-    mkdir -p ${SCRIPT_DIR}/backend/resources/public
-    mkdir -p ${SCRIPT_DIR}/backend/resources/public/thirdparty/fontawesome
+  if [ ! -e ${SCRIPT_DIR}/backend/resources/public-lambdaui ]; then
+    mkdir -p ${SCRIPT_DIR}/backend/resources/public-lambdaui
+    mkdir -p ${SCRIPT_DIR}/backend/resources/public-lambdaui/thirdparty/fontawesome
   fi
 
   echo 'Copying frontend assets to backend'
-  cp frontend/target/* backend/resources/public
-  cp -R frontend/src/thirdparty/fontawesome backend/resources/public/thirdparty
+  cp frontend/target/* backend/resources/public-lambdaui
+  cp -R frontend/src/thirdparty/fontawesome backend/resources/public-lambdaui/thirdparty
   echo 'Compiling backend'
   pushd ${SCRIPT_DIR}/backend > /dev/null
    ./lein jar
@@ -127,7 +127,7 @@ goal:
     test      -- run tests for backend and frontend
 
     Frontend:
-    compile-ui -- Compiles UI into resources/ui/public
+    compile-ui -- Compiles UI into resources/ui/public-lambdaui
     serve-ui  -- Serves UI on port 8080. Watches frontend and recompiles with webpack if necessary.
     serve-backend -- Serves the backend-for-frontend on port 4444
 


### PR DESCRIPTION
Currently I can find the LambdaUI under `/lambdaui/lambdaui/index.html` while the built-in lambdacd-ui can be found under `/lambdaui/`. But by accident I found that the LambdaUI index-html is also found under `/lambdaui/` (where it doesn't work since the relative paths don't work there). So I dug a bit deeper into why this is happening and I think I found the reason, one that could potentially be the source for weird bugs later on: 

Both LambdaCD and LambdaUI put their public resources into a folder named `public` inside their JAR. Once you bring LambdaCD and LambdaUI together in a single classpath, those two folders get merged into one: 

```bash
$ unzip -l foo-0.1.0-SNAPSHOT-standalone.jar | grep public
        0  03-26-17 16:09   public/
     6148  05-03-15 14:01   public/.DS_Store
        0  03-26-17 16:09   public/css/
     6831  03-26-17 16:09   public/css/main.css
        0  02-05-17 16:43   public/css/thirdparty/
        0  02-05-17 16:43   public/css/thirdparty/font-awesome-4.4.0/
        0  02-05-17 16:43   public/css/thirdparty/font-awesome-4.4.0/css/
    32318  02-05-17 16:43   public/css/thirdparty/font-awesome-4.4.0/css/font-awesome.css
[...]
        0  03-26-17 16:09   public/js-gen/
   556146  03-26-17 16:09   public/js-gen/app.js
[...]
        0  03-28-17 09:56   public/thirdparty/fontawesome/
        0  03-28-17 09:56   public/thirdparty/fontawesome/css/
    31000  03-28-17 09:56   public/thirdparty/fontawesome/css/font-awesome.min.css
    37414  03-28-17 09:56   public/thirdparty/fontawesome/css/font-awesome.css
[...]
      865  03-28-17 09:56   public/index.html
     6925  03-28-17 09:56   public/861b175d2baee7d450260c0df8888af3.ico
   549066  03-28-17 09:56   public/bundle.js
```

Currently, this only introduces slightly weird behavior if you play around with paths (why can I find LambdaCD resources in the LambdaUI folder and vice versa?) but is potentially dangerous once paths clash. For example, you can already see in the listing that both libraries use font-awesome but just by chance named the directory differently. What happens if we both name the directory "fontawesome" at some point? Suddenly, the one libraries public resources overwrite the others. Not a nice behavior. 

This PR renames the `public` folder into `public-lambdaui`. I'll also make a similar change in LambdaCD just to be on the safe side in case there are others out there having their own `public` folder. 
