### PR TITLE
href leading to  "/" when clicking on  Lambdacd logo on tog 

### DIFF
--- a/backend/project.clj
+++ b/backend/project.clj
@@ -1,4 +1,4 @@
-(defproject lambdaui "0.4.1-SNAPSHOT"
+(defproject minhtuannguyen/lambdaui "0.4.1.1"
   :description "LambdaCD-Plugin that provides a modern UI for your pipeline."
   :url "https://github.com/sroidl/lambda-ui"
   :license {:name "Apache License 2.0"

--- a/frontend/src/js/main/Header.es6
+++ b/frontend/src/js/main/Header.es6
@@ -50,10 +50,12 @@ export const Header = ({pipelineName, links, showStartBuildButton}) => {
     }
 
     return <div className="appHeader">
-        <div className="logo">
+        <a href="/">
+            <div className="logo">
                 <img src={logo} className="logoImage" alt="logo"/>
                 <span className="logoText">{pipelineName}</span>
-        </div>
+            </div>
+        </a>
         {headerLinks}
         {startBuildButton(showStartBuildButton, triggerNewFn)}
     </div>;


### PR DESCRIPTION
It's very useful to go back to the pipeline's overview by clicking on the logo on top. It's a feature of the legacy Ui which I very appreciate. 