### PR TITLE
Support themes

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,9 @@ __NOTE:__ This feature is experimental and can disappear in any future version.
 ##### __:show-version__ - default: `false`
 If set to `true`  serves another endpoint at `[prefix]/lambdaui/version` and reports the current version of LambdaUI that is used.
 
+##### __:theme__ - optional
+If set to `dark`, it will override some CSS classes of the LambdaUI to display a dark theme experience.
+
 
 
 ## Contribute

--- a/frontend/jest-config.json
+++ b/frontend/jest-config.json
@@ -1,6 +1,6 @@
 {
   "testPathDirs": ["src/js/test", "src/js/main"],
-  "testRegex" : ".*.test.es6$",
+  "testRegex" : ".+\\.(?:test|it)\\.es6",
   "moduleFileExtensions" : ["js", "json", "es6"],
 
   "moduleNameMapper": {

--- a/frontend/src/html/index.html
+++ b/frontend/src/html/index.html
@@ -1,26 +1,66 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="utf-8">
-  <title>LambdaCD</title>
-  <meta name="description" content="">
-  <meta name="author" content="">
+    <meta charset="utf-8">
+    <title>LambdaCD</title>
+    <meta name="description" content="">
+    <meta name="author" content="">
 
-  <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
 
-  <link href="//fonts.googleapis.com/css?family=Raleway:400,300,600" rel="stylesheet" type="text/css">
-  <!--<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.6.3/css/font-awesome.min.css">-->
-  <link rel="stylesheet" href="thirdparty/fontawesome/css/font-awesome.min.css">
+    <link href="//fonts.googleapis.com/css?family=Raleway:400,300,600" rel="stylesheet" type="text/css">
+    <!--<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.6.3/css/font-awesome.min.css">-->
+    <link rel="stylesheet" href="thirdparty/fontawesome/css/font-awesome.min.css">
 
-  <link rel="icon" type="image/png" href="images/favicon.png">
+    <link rel="icon" type="image/png" href="images/favicon.png">
+
+    <style>
+        .center {
+            position: absolute;
+            left: 50%;
+            top: 50%;
+            transform: translate(-50%, -50%);
+        }
+
+        .spinner {
+            width: 40px;
+            height: 40px;
+            -webkit-animation: rotateplane 3s infinite ease-in-out;
+            animation: rotateplane 3s infinite ease-in-out;
+        }
+
+        @keyframes rotateplane {
+            0% {
+                transform: perspective(120px) rotateX(0deg) rotateY(0deg);
+                -webkit-transform: perspective(120px) rotateX(0deg) rotateY(0deg)
+            }
+            25% {
+                transform: perspective(120px) rotateX(-180deg) rotateY(0deg);
+                -webkit-transform: perspective(120px) rotateX(-180deg) rotateY(0deg)
+            }
+            50% {
+                transform: perspective(120px) rotateX(-180deg) rotateY(179.9deg);
+                -webkit-transform: perspective(120px) rotateX(-180deg) rotateY(179.9deg);
+            }
+            75% {
+                transform: perspective(120px) rotateX(0deg) rotateY(180.1deg);
+                -webkit-transform: perspective(120px) rotateX(0deg) rotateY(180.1deg)
+            }
+            100% {
+                transform: perspective(120px) rotateX(0deg) rotateY(0deg);
+                -webkit-transform: perspective(120px) rotateX(0deg) rotateY(0deg)
+            }
+        }
+    </style>
 
 </head>
 <body>
 
-  <div id='entryPoint' class='main'>Loading LambdaUI App.</div>
-  <div id='footer' class='footer'></div>
+<div id='entryPoint' class='main'><img src="http://www.lambda.cd/img/lambdacd-logo.png" class="center spinner"
+        title="Loading LambdaUI App."/></div>
+<div id='footer' class='footer'></div>
 
-  <script type="text/javascript" src="config.js"></script>
-  <script type="text/javascript" src="bundle.js"></script>
+<script type="text/javascript" src="config.js"></script>
+<script type="text/javascript" src="bundle.js"></script>
 </body>
 </html>

--- a/frontend/src/js/main/App.es6
+++ b/frontend/src/js/main/App.es6
@@ -36,6 +36,13 @@ export class LambdaUI {
         pollBuildDetails(backend, appStore);
 
         const rootElement = document.getElementById("entryPoint");
+        const theme = window.lambdaui.config.theme;
+
+        const knownThemes = ["dark"];
+
+        if (knownThemes.includes(theme)) {
+            rootElement.setAttribute("class", rootElement.getAttribute("class") + "--" + theme);
+        }
         ReactDOM.render(<Provider store={this.appStore()}>
             <div>
                 <Header />

--- a/frontend/src/sass/buildSummary.sass
+++ b/frontend/src/sass/buildSummary.sass
@@ -10,7 +10,7 @@
   content: ''
   width: 26px
   background-color: #FFFFFF
-  transistion: width 0.1s ease-in-out
+  transition: width 0.1s ease-in-out
 
 .buildSummary
   margin-bottom: 10px
@@ -86,7 +86,7 @@
 // Open
 .buildSummary
   &.open:before
-    width: 10px
+    width: 10px !important
     transition: width 0.1s ease-in-out
     z-index: 1
 

--- a/frontend/src/sass/colors.sass
+++ b/frontend/src/sass/colors.sass
@@ -5,7 +5,6 @@ $red: #942629
 $green: #75BD70
 $black: #333
 $peru: #CD853F
-$background-color: #3D3636
 $buildInfo-open: #F2F0EB
 $white: #FFFFFF
 $dark-grey: #867976

--- a/frontend/src/sass/footer.sass
+++ b/frontend/src/sass/footer.sass
@@ -1,11 +1,10 @@
 @import 'colors'
 
-
-.main
+#entryPoint
   min-height: 100%
   margin-bottom: -40px
 
-.main:after
+#entryPoint:after
   content: ""
   display: block
   height: 40px

--- a/frontend/src/sass/main.sass
+++ b/frontend/src/sass/main.sass
@@ -1,5 +1,6 @@
 @import 'colors'
 @import 'buildSummary'
+@import 'themeDark'
 
 html
   height: 100%

--- a/frontend/src/sass/themeDark.sass
+++ b/frontend/src/sass/themeDark.sass
@@ -58,6 +58,8 @@ $fuckin-dark-grey: #090909
                 background-color: $brighter-blue
             &.waiting .buildIcon
                 background-color: $orange
+            &.killed .buildIcon
+                background-color: $brighter-grey
             &.pending .buildIcon
                 display: none
 
@@ -109,6 +111,8 @@ $fuckin-dark-grey: #090909
             background-color: $orange
         &.running:before
             background-color: $brighter-blue
+        &.killed:before
+            background-color: $brighter-grey
         &.unknown:before
             background-color: $dark-grey
 
@@ -175,34 +179,28 @@ $fuckin-dark-grey: #090909
                 top: 20px
                 left: 25px
 
-    // quick details
     .quickStep
+        border: 1px solid $dark-light-grey
         &:before
             background-color: $dark-light-grey
 
         &.success
             background-color: $brighter-green
-            border: 1px solid $dark-light-grey
 
         &.failure
             background-color: $brighter-red
-            border: 1px solid $dark-light-grey
 
         &.waiting
             background-color: $orange
-            border: 1px solid $dark-light-grey
 
         &.pending
-            background-color: darken($dark-light-grey, 20%)
-            border: 1px solid $dark-light-grey
+            background-color: $dark-light-grey
 
         &.killed
-            background-color: $darker-grey
-            border: 1px solid $dark-light-grey
+            background-color: $brighter-grey
 
         &.running
             background-color: $brighter-blue
-            border: 1px solid $dark-light-grey
 
     .quickSubsteps
         >.quickStep:last-of-type:after

--- a/frontend/src/sass/themeDark.sass
+++ b/frontend/src/sass/themeDark.sass
@@ -1,0 +1,307 @@
+@import 'colors'
+
+$brighter-blue: #136FDB
+$brighter-red: #d71318
+$brighter-green: #37BF2D
+$orange: #FF8608
+$brighter-grey: #808080
+$darker-grey: #454545
+$even-darker-grey: #2d2d2d
+$really-dark-grey: #191919
+$extreme-dark-grey: #151515
+$fuckin-dark-grey: #090909
+
+.main--dark
+    background-color: $really-dark-grey
+
+    /*** loading message ***/
+    .loadingMessage
+        color: $dark-light-grey
+
+    /*** generel stuff ***/
+    // links
+    .link
+        color: $dark-light-grey
+        border-right-color: darken($dark-grey, 10%)
+
+    .link:hover, .link:active, .link:focus
+        color: $lightGrey
+
+    /*** Header ***/
+    .appHeader
+        background-color: $even-darker-grey
+        border-bottom-color: $dark-light-grey
+
+    // run button...
+    .runButton,
+    button.buildStepLayer__tab
+        background: lighten($even-darker-grey, 10%)
+        color: lighten($dark-grey, 10%)
+        border-color: lighten($dark-grey, 10%)
+
+        &:hover, &:active, &:focus
+            background: darken($dark-grey, 10%)
+            color: $dark-light-grey
+            border: 1px solid $dark-light-grey
+
+    /*** build details ***/
+    .BuildDetails
+        color: #c4c4c4
+        background-color: $even-darker-grey
+        &:nth-child(even)
+            background-color: lighten($even-darker-grey, 3%)
+
+        .tools
+            & .toolbar
+                border-top: 1px solid darken(#707070, 10%)
+                border-bottom: none
+                background-color: #707070
+
+        .BuildStep
+            &.success .buildIcon
+                background-color: $brighter-green
+            &.failure .buildIcon
+                background-color: $brighter-red
+            &.running .buildIcon
+                background-color: $brighter-blue
+            &.waiting .buildIcon
+                background-color: $orange
+
+            &.LowermostStep
+                background-color: #707070
+                color: #000
+                border: 1px solid #707070
+                margin: 0px 10px
+
+            &.WithSubsteps
+                border-width: 0px 2px
+                border-color: $dark-light-grey
+                border-style: solid
+
+            &:before , &:after
+                background-color: $dark-light-grey
+
+        .BuildStepWithSubsteps
+            background-color: transparentize($dark-light-grey, 0.9)
+            border-color: $very-dark-grey
+
+        .ParallelLine
+            border-color: $dark-light-grey
+            &:last-of-type
+                border-color: transparent
+
+        .BuildStepParallel
+            background-color: transparentize($dark-light-grey, 0.9)
+            border: 1px solid $very-dark-grey
+
+    /*** build summary ***/
+
+    // summary
+    .buildSummary
+        border-bottom: 1px solid $really-dark-grey
+        background-color: $even-darker-grey
+
+        &:before
+            width: 65px
+
+        &:nth-child(even)
+            background-color: lighten($even-darker-grey, 3%)
+
+        & .buildNumber
+            color: $dark-light-grey
+
+        &.success:before
+            background-color: $brighter-green
+        &.failed:before
+            background-color: $brighter-red
+        &.running:before
+            background-color: $brighter-blue
+        &.unknown:before
+            background-color: $dark-grey
+
+    // success
+    .buildSummary.success:before
+        background-color: $brighter-green
+
+    .buildSummary.open.success
+        color: $brighter-green
+
+    .buildSummary.open.success .buildInfo
+        & .buildNumber
+            color: $brighter-green
+        & .buildIcon
+            color: $brighter-green
+            font-size: 30px
+            left: 20px
+            top: 9px
+
+    // waiting
+    .buildSummary.waiting:before
+        background-color: $orange
+
+    .buildSummary.open.waiting
+        color: $orange
+
+    .buildSummary.open.waiting .buildInfo
+        & .buildNumber
+            color: $orange
+        & .buildIcon
+            color: $orange
+            font-size: 30px
+            left: 20px
+            top: 9px
+
+    // failed
+    .buildSummary.failed:before
+        background-color: $brighter-red
+
+    .buildSummary.open.failed
+        color: $brighter-red
+
+    .buildSummary.open.failed .buildInfo
+        & .buildNumber
+            color: $brighter-red
+        & .buildIcon
+            color: $brighter-red
+            font-size: 30px
+            left: 20px
+            top: 9px
+
+    // running
+    .buildSummary.running:before
+        background-color: $brighter-blue
+
+    .buildSummary.open.running
+        color: $brighter-blue
+
+    .buildSummary.open.running .buildInfo
+        & .buildNumber
+            color: $brighter-blue
+        & .buildIcon
+            color: $brighter-blue
+            font-size: 30px
+            left: 20px
+            top: 9px
+
+    // killed or Unknown
+    .buildSummary.killed:before
+        background-color: $brighter-grey
+
+    .buildSummary.open.killed
+        color: $brighter-grey
+
+    .buildSummary.open.killed .buildInfo
+        & .buildNumber
+            color: $brighter-grey
+        & .buildIcon
+            color: $brighter-grey
+            font-size: 30px
+            left: 20px
+            top: 9px
+
+    // build info
+    .buildSummary .buildInfo
+        & .buildInfoRow
+            display: inline-block
+            vertical-align: middle
+            text-align: center
+            padding: 8px
+            font-size: 1em
+            color: $dark-light-grey
+            &.time
+                text-align: left
+
+
+    // build info icon
+    .buildSummary .buildInfo .buildIcon
+        top: 20px
+        left: 25px
+
+    // build info open
+    .buildSummary.open .buildInfo
+        color: $darker-grey
+        border-bottom: none
+        & .buildIcon
+            left: 25px
+            animation-name: rubberBand
+            animation-duration: 0.5s
+            animation-fill-mode: both
+            color: $white
+
+    // quick details
+    .quickStep
+        &:before
+            background-color: $dark-light-grey
+
+        &.success
+            background-color: $brighter-green
+            border: 1px solid $dark-light-grey
+
+        &.failure
+            background-color: $brighter-red
+            border: 1px solid $dark-light-grey
+
+        &.waiting
+            background-color: $orange
+            border: 1px solid $dark-light-grey
+
+        &.pending
+            background-color: darken($dark-light-grey, 20%)
+            border: 1px solid $dark-light-grey
+
+        &.killed
+            background-color: $darker-grey
+            border: 1px solid $dark-light-grey
+
+        &.running
+            background-color: $brighter-blue
+            border: 1px solid $dark-light-grey
+
+    .quickSubsteps
+        >.quickStep:last-of-type:after
+            background-color: $dark-light-grey
+
+    .quickStepContainer
+        background-color: transparentize($dark-light-grey, 0.8)
+
+    .buildStepLayer
+        background-color: $darker-grey
+        color: $dark-light-grey
+        &__text
+            border: 3px solid $even-darker-grey
+            border-radius: 5px
+
+.main--dark + .footer
+    .version-info__link
+        & > a
+            color: $darker-grey
+
+        & > a:hover, a:active, a:focus
+            color: lighten($darker-grey, 20%)
+
+=keyframes($name)
+    @-webkit-keyframes #{$name}
+        @content
+    @-moz-keyframes #{$name}
+        @content
+    @-ms-keyframes #{$name}
+        @content
+    @keyframes #{$name}
+        @content
+
++keyframes(rubberBand)
+    0%
+        transform: scale3d(1, 1, 1)
+        color: $white
+    30%
+        transform: scale3d(1.25, 0.75, 1)
+    40%
+        transform: scale3d(0.75, 1.25, 1)
+    50%
+        transform: scale3d(1.15, 0.85, 1)
+    65%
+        transform: scale3d(.95, 1.05, 1)
+    75%
+        transform: scale3d(1.05, .95, 1)
+    100%
+        transform: scale3d(1, 1, 1)

--- a/frontend/src/sass/themeDark.sass
+++ b/frontend/src/sass/themeDark.sass
@@ -14,37 +14,29 @@ $fuckin-dark-grey: #090909
 .main--dark
     background-color: $really-dark-grey
 
-    /*** loading message ***/
     .loadingMessage
         color: $dark-light-grey
 
-    /*** generel stuff ***/
-    // links
     .link
         color: $dark-light-grey
         border-right-color: darken($dark-grey, 10%)
+        &:hover, &:active, &:focus
+            color: $lightGrey
 
-    .link:hover, .link:active, .link:focus
-        color: $lightGrey
-
-    /*** Header ***/
     .appHeader
         background-color: $even-darker-grey
         border-bottom-color: $dark-light-grey
 
-    // run button...
     .runButton,
     button.buildStepLayer__tab
         background: lighten($even-darker-grey, 10%)
         color: lighten($dark-grey, 10%)
         border-color: lighten($dark-grey, 10%)
-
         &:hover, &:active, &:focus
             background: darken($dark-grey, 10%)
             color: $dark-light-grey
             border: 1px solid $dark-light-grey
 
-    /*** build details ***/
     .BuildDetails
         color: #c4c4c4
         background-color: $even-darker-grey
@@ -66,37 +58,36 @@ $fuckin-dark-grey: #090909
                 background-color: $brighter-blue
             &.waiting .buildIcon
                 background-color: $orange
+            &.pending .buildIcon
+                display: none
 
             &.LowermostStep
                 background-color: #707070
                 color: #000
                 border: 1px solid #707070
-                margin: 0px 10px
+                margin: 0 10px
 
             &.WithSubsteps
-                border-width: 0px 2px
+                border-width: 0 2px
                 border-color: $dark-light-grey
                 border-style: solid
 
             &:before , &:after
                 background-color: $dark-light-grey
 
-        .BuildStepWithSubsteps
-            background-color: transparentize($dark-light-grey, 0.9)
-            border-color: $very-dark-grey
+            &WithSubsteps
+                background-color: transparentize($dark-light-grey, 0.9)
+                border-color: $very-dark-grey
+
+            &Parallel
+                background-color: transparentize($dark-light-grey, 0.9)
+                border: 1px solid $very-dark-grey
 
         .ParallelLine
             border-color: $dark-light-grey
             &:last-of-type
                 border-color: transparent
 
-        .BuildStepParallel
-            background-color: transparentize($dark-light-grey, 0.9)
-            border: 1px solid $very-dark-grey
-
-    /*** build summary ***/
-
-    // summary
     .buildSummary
         border-bottom: 1px solid $really-dark-grey
         background-color: $even-darker-grey
@@ -107,126 +98,82 @@ $fuckin-dark-grey: #090909
         &:nth-child(even)
             background-color: lighten($even-darker-grey, 3%)
 
-        & .buildNumber
+        .buildNumber
             color: $dark-light-grey
 
         &.success:before
             background-color: $brighter-green
         &.failed:before
             background-color: $brighter-red
+        &.waiting:before
+            background-color: $orange
         &.running:before
             background-color: $brighter-blue
         &.unknown:before
             background-color: $dark-grey
 
-    // success
-    .buildSummary.success:before
-        background-color: $brighter-green
+        &.open
+            .buildInfo
+                color: $darker-grey
+                border-bottom: none
+                .buildIcon
+                    top: 9px
+                    left: 20px
+                    font-size: 30px
+                    color: $white
+                    animation-name: rubberBand
+                    animation-duration: 0.5s
+                    animation-fill-mode: both
 
-    .buildSummary.open.success
-        color: $brighter-green
+            &.success
+                color: $brighter-green
+                .buildInfo
+                    & .buildNumber
+                        color: $brighter-green
+                    & .buildIcon
+                        color: $brighter-green
+            &.waiting
+                color: $orange
+                .buildInfo
+                    & .buildNumber
+                        color: $orange
+                    & .buildIcon
+                        color: $orange
+            &.failed
+                color: $brighter-red
+                .buildInfo
+                    & .buildNumber
+                        color: $brighter-red
+                    & .buildIcon
+                        color: $brighter-red
+            &.running
+                color: $brighter-blue
+                .buildInfo
+                    & .buildNumber
+                        color: $brighter-blue
+                    & .buildIcon
+                        color: $brighter-blue
+            &.killed
+                color: $brighter-grey
+                .buildInfo
+                    & .buildNumber
+                        color: $brighter-grey
+                    & .buildIcon
+                        color: $brighter-grey
 
-    .buildSummary.open.success .buildInfo
-        & .buildNumber
-            color: $brighter-green
-        & .buildIcon
-            color: $brighter-green
-            font-size: 30px
-            left: 20px
-            top: 9px
-
-    // waiting
-    .buildSummary.waiting:before
-        background-color: $orange
-
-    .buildSummary.open.waiting
-        color: $orange
-
-    .buildSummary.open.waiting .buildInfo
-        & .buildNumber
-            color: $orange
-        & .buildIcon
-            color: $orange
-            font-size: 30px
-            left: 20px
-            top: 9px
-
-    // failed
-    .buildSummary.failed:before
-        background-color: $brighter-red
-
-    .buildSummary.open.failed
-        color: $brighter-red
-
-    .buildSummary.open.failed .buildInfo
-        & .buildNumber
-            color: $brighter-red
-        & .buildIcon
-            color: $brighter-red
-            font-size: 30px
-            left: 20px
-            top: 9px
-
-    // running
-    .buildSummary.running:before
-        background-color: $brighter-blue
-
-    .buildSummary.open.running
-        color: $brighter-blue
-
-    .buildSummary.open.running .buildInfo
-        & .buildNumber
-            color: $brighter-blue
-        & .buildIcon
-            color: $brighter-blue
-            font-size: 30px
-            left: 20px
-            top: 9px
-
-    // killed or Unknown
-    .buildSummary.killed:before
-        background-color: $brighter-grey
-
-    .buildSummary.open.killed
-        color: $brighter-grey
-
-    .buildSummary.open.killed .buildInfo
-        & .buildNumber
-            color: $brighter-grey
-        & .buildIcon
-            color: $brighter-grey
-            font-size: 30px
-            left: 20px
-            top: 9px
-
-    // build info
-    .buildSummary .buildInfo
-        & .buildInfoRow
-            display: inline-block
-            vertical-align: middle
-            text-align: center
-            padding: 8px
-            font-size: 1em
-            color: $dark-light-grey
-            &.time
-                text-align: left
-
-
-    // build info icon
-    .buildSummary .buildInfo .buildIcon
-        top: 20px
-        left: 25px
-
-    // build info open
-    .buildSummary.open .buildInfo
-        color: $darker-grey
-        border-bottom: none
-        & .buildIcon
-            left: 25px
-            animation-name: rubberBand
-            animation-duration: 0.5s
-            animation-fill-mode: both
-            color: $white
+        .buildInfo
+            .buildInfoRow
+                display: inline-block
+                vertical-align: middle
+                text-align: center
+                padding: 8px
+                font-size: 1em
+                color: $dark-light-grey
+                &.time
+                    text-align: left
+            .buildIcon
+                top: 20px
+                left: 25px
 
     // quick details
     .quickStep


### PR DESCRIPTION
hey,
i added the possibility to easily add alternative styles to allow themes.
by default everything will look and behave like before but you can optionally add 
`theme: "dark"` to the config to activate the dark theme. if the config will include unknown strings (atm it's only "dark") it will fallback to default as well.