### PR TITLE
Remove use of deprecated apis

### DIFF
--- a/backend/src/lambdaui/api_legacy.clj
+++ b/backend/src/lambdaui/api_legacy.clj
@@ -13,7 +13,8 @@
             [lambdaui.common.details :as details]
             [lambdaui.common.collections :refer [deep-merge]]
             [lambdacd.state.core :as lambdacd-state]
-            [lambdaui.json-util :as json-util]))
+            [lambdaui.json-util :as json-util]
+            [lambdacd.execution.core :as execution-core]))
 
 (defn only-matching-step [event-updates-ch build-id step-id]
   (let [result (async/chan)
@@ -109,7 +110,7 @@
       (GET "/builds/:build-id" [build-id :as request] (wrap-websocket request (partial websocket-connection-for-details pipeline build-id)))
       (GET "/builds/:build-id/:step-id" [build-id step-id :as request] (output-buildstep-websocket pipeline request build-id step-id))
       (POST "/builds/:buildnumber/:step-id/retrigger" [buildnumber step-id]
-        (let [new-buildnumber (core/retrigger pipeline-def ctx (Integer/parseInt buildnumber) (str->step-id step-id))]
+        (let [new-buildnumber (execution-core/retrigger-pipeline-async pipeline-def ctx (Integer/parseInt buildnumber) (str->step-id step-id))]
           (json-util/json-response {:build-number new-buildnumber})))
       (POST "/builds/:buildnumber/:step-id/kill" [buildnumber step-id] (kill-step buildnumber step-id ctx)))))
 

--- a/backend/src/lambdaui/api_legacy.clj
+++ b/backend/src/lambdaui/api_legacy.clj
@@ -8,7 +8,6 @@
             [clojure.core.async :as async]
             [clojure.data.json :as json]
             [clojure.string :as s]
-            [lambdacd.core :as core]
             [lambdaui.common.common :refer [finished? step-id->str str->step-id]]
             [lambdaui.common.details :as details]
             [lambdaui.common.collections :refer [deep-merge]]
@@ -99,7 +98,7 @@
       (do
         (println "Kill Step " build-id " - " step-id)
         (swap! killed-steps (fn [old-value] (conj old-value identifier)))
-        (core/kill-step ctx (Integer/parseInt build-id) (str->step-id step-id))
+        (execution-core/kill-step ctx (Integer/parseInt build-id) (str->step-id step-id))
         {:status 200})
       (do (println "Already killed step " identifier) {:status 403} ))))
 

--- a/backend/src/lambdaui/common/common.clj
+++ b/backend/src/lambdaui/common/common.clj
@@ -1,10 +1,6 @@
 (ns lambdaui.common.common
-  (:require [lambdacd.internal.pipeline-state :as state]
-            [clojure.string :as string]
+  (:require [clojure.string :as string]
             [lambdacd.util :as util]))
-
-(defn state-from-pipeline [pipeline]
-  (state/get-all (:pipeline-state-component (:context pipeline))))
 
 (defn finished? [status]
   (contains? #{:success :failure :killed} status))

--- a/backend/src/lambdaui/common/common.clj
+++ b/backend/src/lambdaui/common/common.clj
@@ -1,6 +1,6 @@
 (ns lambdaui.common.common
-  (:require [clojure.string :as string]
-            [lambdacd.util :as util]))
+  (:require [clojure.string :as string])
+  (:import java.lang.Integer))
 
 (defn finished? [status]
   (contains? #{:success :failure :killed} status))
@@ -9,5 +9,5 @@
   (clojure.string/join "-" step-id))
 
 (defn str->step-id [dash-seperated-step-id]
-  (map util/parse-int (string/split dash-seperated-step-id #"-")))
+  (map #(Integer/parseInt %) (string/split dash-seperated-step-id #"-")))
 

--- a/backend/src/lambdaui/common/details.clj
+++ b/backend/src/lambdaui/common/details.clj
@@ -1,7 +1,9 @@
 (ns lambdaui.common.details
   (:require [lambdaui.common.common :as common]
             [lambdacd.presentation.unified :as presentation]
-            [lambdacd.state.core :as state]))
+            [lambdacd.state.core :as state]
+            [lambdacd.presentation.pipeline-structure :as pipeline-structure]
+            [lambdacd.presentation.unified :as unified]))
 
 (defn- to-iso-string [timestamp]
   (when timestamp
@@ -39,8 +41,12 @@
         children (if-let [children (:children step)] {:steps (map (partial to-output-format trigger-path-prefix) children)} {})]
     (merge base type children trigger)))
 
+(defn- unified-presentation [pipeline-def step-results]
+  (let [structure (pipeline-structure/pipeline-display-representation pipeline-def)]
+    (unified/pipeline-structure-with-step-results structure step-results)))
+
 (defn build-details-from-pipeline [pipeline-def pipeline-state build-id ui-config]
-  (let [unified-steps-map (->> (presentation/unified-presentation pipeline-def pipeline-state)
+  (let [unified-steps-map (->> (unified-presentation pipeline-def pipeline-state)
                                (map (partial to-output-format (:path-prefix ui-config "")))
                                (map (fn [step] [(:stepId step) step]))
                                (into {}))

--- a/backend/src/lambdaui/common/details.clj
+++ b/backend/src/lambdaui/common/details.clj
@@ -1,6 +1,7 @@
 (ns lambdaui.common.details
   (:require [lambdaui.common.common :as common]
-            [lambdacd.presentation.unified :as presentation]))
+            [lambdacd.presentation.unified :as presentation]
+            [lambdacd.state.core :as state]))
 
 (defn- to-iso-string [timestamp]
   (when timestamp
@@ -49,6 +50,6 @@
      :steps   steps}))
 
 (defn build-details-response [pipeline build-id]
-  (let [build-state (get (common/state-from-pipeline pipeline) (Integer/parseInt build-id))
+  (let [build-state (state/get-step-results (:context pipeline) (Integer/parseInt build-id))
         pipeline-def (:pipeline-def pipeline)]
     (build-details-from-pipeline pipeline-def build-state build-id (get-in pipeline [:context :config :ui-config]))))

--- a/backend/src/lambdaui/common/summaries.clj
+++ b/backend/src/lambdaui/common/summaries.clj
@@ -1,6 +1,7 @@
 (ns lambdaui.common.summaries
   (:require [lambdacd.presentation.pipeline-state :as presentation]
-            [lambdaui.common.step-state :as steps]))
+            [lambdaui.common.step-state :as steps]
+            [lambdacd.state.core :as state]))
 
 
 
@@ -34,11 +35,9 @@
    :endTime     (extract-end-time build-steps)
    :duration    (presentation/build-duration build-steps)})
 
-
-
-
-(defn summaries [pipeline-state]
+(defn summaries [ctx]
   {:summaries
-   (map #(pipeline-state-entry->summaries-entry (first %) (last %)) pipeline-state)})
+   (for [build-number (state/all-build-numbers ctx)]
+     (pipeline-state-entry->summaries-entry build-number (state/get-step-results ctx build-number)))})
 
 

--- a/backend/src/lambdaui/json_util.clj
+++ b/backend/src/lambdaui/json_util.clj
@@ -1,0 +1,16 @@
+(ns lambdaui.json-util
+  (:require [cheshire.core :as ch]
+            [clj-time.format :as f]
+            [cheshire.generate :as chg])
+  (:import (com.fasterxml.jackson.core JsonGenerator)
+           (org.joda.time DateTime)))
+
+(def iso-formatter (f/formatters :date-time))
+
+(chg/add-encoder DateTime (fn [v ^JsonGenerator jsonGenerator] (.writeString jsonGenerator ^String (f/unparse iso-formatter v))))
+
+(defn to-json [v] (ch/generate-string v))
+(defn json-response [data]
+  {:headers { "Content-Type" "application/json;charset=UTF-8"}
+   :body (to-json data)
+   :status 200 })

--- a/backend/src/lambdaui/polling.clj
+++ b/backend/src/lambdaui/polling.clj
@@ -2,18 +2,14 @@
   (:use [lambdaui.common.summaries])
   (:require [compojure.core :as comp :refer [routes GET]]
             [ring.util.response :refer [header response]]
-            [ring.middleware.json :refer [wrap-json-response]]
-            [lambdacd.internal.pipeline-state :as state]))
-
-(defn state-from-pipeline [pipeline]
-  (state/get-all (:pipeline-state-component (:context pipeline))))
+            [ring.middleware.json :refer [wrap-json-response]]))
 
 (defn- cross-origin-response [data]
   (header (response data) "Access-Control-Allow-Origin" "*"))
 
 
 (defn summary-response [pipeline]
-  (lambdacd.util/to-json (summaries (state-from-pipeline pipeline))))
+  (lambdacd.util/to-json (summaries (:context pipeline))))
 
 (defn polling-routes [pipeline]
   (routes

--- a/backend/src/lambdaui/polling.clj
+++ b/backend/src/lambdaui/polling.clj
@@ -1,15 +1,15 @@
 (ns lambdaui.polling
   (:use [lambdaui.common.summaries])
-  (:require [compojure.core :as comp :refer [routes GET]]
+  (:require [compojure.core :refer [routes GET]]
             [ring.util.response :refer [header response]]
-            [ring.middleware.json :refer [wrap-json-response]]))
+            [ring.middleware.json :refer [wrap-json-response]]
+            [lambdaui.json-util :as json-util]))
 
 (defn- cross-origin-response [data]
   (header (response data) "Access-Control-Allow-Origin" "*"))
 
-
 (defn summary-response [pipeline]
-  (lambdacd.util/to-json (summaries (:context pipeline))))
+  (json-util/to-json (summaries (:context pipeline))))
 
 (defn polling-routes [pipeline]
   (routes

--- a/backend/src/lambdaui/trigger.clj
+++ b/backend/src/lambdaui/trigger.clj
@@ -1,7 +1,7 @@
 (ns lambdaui.trigger
   (:require [clojure.core.async :as async]
-            [lambdacd.execution :as execution]
-            [clojure.walk :refer [keywordize-keys]]))
+            [clojure.walk :refer [keywordize-keys]]
+            [lambdacd.execution.core :as execution-core]))
 
 
 ;{:post [(v/is-not-nil-or-empty? (:branch (:global %)))
@@ -13,5 +13,5 @@
 
     ;(println "Starting new build " )
     ;(when-let [git-commit (:git (keywordize-keys query-param))] (println "requested commit was" git-commit))
-    (execution/run pipeline-def context)
+    (execution-core/run-pipeline pipeline-def context)
     ))

--- a/backend/test/lambdaui/api_test.clj
+++ b/backend/test/lambdaui/api_test.clj
@@ -123,7 +123,7 @@
     (clear-killed-atom)
 
     (let [kill-counter (atom 0)]
-      (with-redefs [lambdacd.core/kill-step (fn [& _] (swap! kill-counter inc))]
+      (with-redefs [lambdacd.execution.core/kill-step (fn [& _] (swap! kill-counter inc))]
         (subject/kill-step "1" "1" nil)
         (subject/kill-step "1" "1" nil)
 

--- a/backend/test/lambdaui/api_test.clj
+++ b/backend/test/lambdaui/api_test.clj
@@ -3,7 +3,7 @@
             [lambdaui.api-legacy :as subject]
             [lambdacd.steps.control-flow :as ctrl-flow]
             [lambdacd.event-bus :as event-bus]
-            [lambdacd.internal.pipeline-state :as state]
+            [lambdacd.state.core :as state]
             [org.httpkit.server :as httpkit-server]
             [shrubbery.core :refer :all]
             [clojure.core.async :as async]
@@ -25,7 +25,7 @@
                   (send! [ws-ch data] (async/>!! sent-channel data)))]
       (with-redefs [event-bus/subscribe (fn [ctx topic] nil)
                     event-bus/only-payload (fn [subscription] event-channel)
-                    state/get-all (fn [_] {})]
+                    state/get-step-results (fn [_ _] {})]
         (subject/output-events nil ws-ch 1 "2-1")
         (async/>!! event-channel {:build-number 1 :step-id [2 1] :step-result {:foo :bar}})
         (async/<!! sent-channel)                            ;ignore first msg. not part of test
@@ -43,7 +43,7 @@
                   (send! [ws-ch data] (async/>!! sent-channel data)))]
       (with-redefs [event-bus/subscribe (fn [ctx topic] nil)
                     event-bus/only-payload (fn [subscription] event-channel)
-                    state/get-all (fn [_] {})]
+                    state/get-step-results (fn [_ _] {})]
         (subject/output-events nil ws-ch 1 "2-1")
         (async/>!! event-channel {:build-number 1 :step-id [2 1] :stepResult {:status :running}})
         (async/>!! event-channel {:build-number 1 :step-id [2 1] :stepResult {:status :success}})
@@ -78,7 +78,7 @@
 (deftest details-websocket
   (testing "that a json payload is sent through the ws channel"
 
-    (with-redefs [lambdacd.internal.pipeline-state/get-all (fn [_] {})]
+    (with-redefs [state/get-step-results (fn [_ _] {})]
       (let [pipeline {:pipeline-def pipeline-with-substeps}
             build-id "1"
             ws-ch (async/chan 1)]

--- a/backend/test/lambdaui/fixtures/steps.clj
+++ b/backend/test/lambdaui/fixtures/steps.clj
@@ -1,5 +1,5 @@
 (ns lambdaui.fixtures.steps
-  (:require [lambdacd.steps.support :refer [capture-output]])
+  (:require [lambdacd.stepsupport.output :refer [capture-output]])
   )
 
 (defn success [_ _]

--- a/backend/test/lambdaui/test_server.clj
+++ b/backend/test/lambdaui/test_server.clj
@@ -2,12 +2,11 @@
   (:require [lambdacd.core :as lambdacd]
             [lambdacd.execution.core :refer [run-pipeline]]
             [lambdacd.execution.internal.kill :refer [kill-all-pipelines]]
-            [lambdacd.util :refer [create-temp-dir]]
+            [lambdaui.test-utils :refer [create-temp-dir]]
             [lambdaui.core :as ui]
             [org.httpkit.server :refer [run-server]]
             [clojure.core.async :as async]
-            [clojure.tools.logging :as log])
-  )
+            [clojure.tools.logging :as log]))
 
 (defn stop-server! [server-atom]
   (log/info "Stopping server")

--- a/backend/test/lambdaui/test_utils.clj
+++ b/backend/test/lambdaui/test_utils.clj
@@ -1,0 +1,11 @@
+(ns lambdaui.test-utils
+  (:import (java.nio.file.attribute FileAttribute)
+           (java.nio.file Files)))
+
+(defn- no-file-attributes []
+  (into-array FileAttribute []))
+
+(def temp-prefix "lambdaui-test")
+
+(defn create-temp-dir []
+   (str (Files/createTempDirectory temp-prefix (no-file-attributes))))

--- a/backend/test/lambdaui/testpipeline/artifact_pipeline.clj
+++ b/backend/test/lambdaui/testpipeline/artifact_pipeline.clj
@@ -2,8 +2,7 @@
   (:use [compojure.core])
   (:require [lambdacd.steps.shell :as shell]
             [lambdacd.steps.manualtrigger :refer [wait-for-manual-trigger]]
-            [lambdacd.steps.control-flow :refer [either with-workspace in-parallel run] :as step]
-            [lambdacd.steps.support :as support]
+            [lambdacd.steps.control-flow :refer [either with-workspace in-parallel run]]
             [lambdacd-artifacts.core :as artifacts]))
 
 (defn write-a-file [{cwd :cwd} ctx]

--- a/backend/test/lambdaui/testpipeline/core.clj
+++ b/backend/test/lambdaui/testpipeline/core.clj
@@ -10,7 +10,9 @@
             [ring.middleware.cors :refer [wrap-cors]]
             [lambdacd.presentation.unified :as presentation]
             [lambdacd-artifacts.core :as artifacts]
-            [lambdaui.test-utils :as test-utils])
+            [lambdaui.test-utils :as test-utils]
+            [lambdacd.presentation.pipeline-structure :as pipeline-structure]
+            [lambdacd.presentation.unified :as unified])
 
   (:use [lambdacd.runners]))
 
@@ -70,5 +72,6 @@
   (-main))
 
 (let [pipeline-def (:pipeline-def @current-pipeline)
-      pipeline-state (:pipeline-state-component (:context @current-pipeline))]
-  (presentation/unified-presentation pipeline-def pipeline-state))
+      pipeline-state (:pipeline-state-component (:context @current-pipeline))
+      structure (pipeline-structure/pipeline-display-representation pipeline-def)]
+  (unified/pipeline-structure-with-step-results structure pipeline-state))

--- a/backend/test/lambdaui/testpipeline/core.clj
+++ b/backend/test/lambdaui/testpipeline/core.clj
@@ -1,22 +1,16 @@
 (ns lambdaui.testpipeline.core
-  (:require [lambdacd-git.core :as git]
-            [lambdacd.core :as lambdacd]
-            [lambdacd.util :as util]
-            [lambdacd.runners :as runners]
+  (:require [lambdacd.core :as lambdacd]
             [org.httpkit.server :as http]
             [lambdaui.testpipeline.simple-pipeline :as pipe]
             [lambdaui.testpipeline.trigger-pipeline :as pipe-with-trigger]
             [lambdaui.testpipeline.long-running :as long-running-pipe]
             [lambdaui.testpipeline.artifact-pipeline :as artifact-pipeline]
             [lambdaui.core :as ui]
-            [clojure.core.async :as async :refer [go <! <!! >! >!!]]
-            [lambdacd.event-bus :as events]
-            [lambdacd.event-bus :as event-bus]
-            [lambdaui.fixtures.pipelines :as fixture]
             [compojure.core :refer [routes GET context POST]]
             [ring.middleware.cors :refer [wrap-cors]]
             [lambdacd.presentation.unified :as presentation]
-            [lambdacd-artifacts.core :as artifacts])
+            [lambdacd-artifacts.core :as artifacts]
+            [lambdaui.test-utils :as test-utils])
 
   (:use [lambdacd.runners]))
 
@@ -33,10 +27,10 @@
 (def artifacts-path-context "/artifacts")
 
 (defn start-server [port]
-  (let [small-pipeline (lambdacd/assemble-pipeline pipe/small-pipeline {:home-dir (util/create-temp-dir) :name "SMALL_PIPELINE"})
-        simple-pipeline (lambdacd/assemble-pipeline pipe/pipeline-structure {:home-dir (util/create-temp-dir) :name "SIMPLE PIPELINE" :ui-config ui-config})
-        trigger-pipeline (lambdacd/assemble-pipeline pipe-with-trigger/pipeline-structure {:home-dir (util/create-temp-dir) :name "TRIGGER PIPELINE"})
-        long-running-pipeline (lambdacd/assemble-pipeline long-running-pipe/pipeline-structure {:home-dir (util/create-temp-dir) :name "LONG-RUNNING PIPELINE"})
+  (let [small-pipeline (lambdacd/assemble-pipeline pipe/small-pipeline {:home-dir (test-utils/create-temp-dir) :name "SMALL_PIPELINE"})
+        simple-pipeline (lambdacd/assemble-pipeline pipe/pipeline-structure {:home-dir (test-utils/create-temp-dir) :name "SIMPLE PIPELINE" :ui-config ui-config})
+        trigger-pipeline (lambdacd/assemble-pipeline pipe-with-trigger/pipeline-structure {:home-dir (test-utils/create-temp-dir) :name "TRIGGER PIPELINE"})
+        long-running-pipeline (lambdacd/assemble-pipeline long-running-pipe/pipeline-structure {:home-dir (test-utils/create-temp-dir) :name "LONG-RUNNING PIPELINE"})
         artifact-pipeline (lambdacd/assemble-pipeline artifact-pipeline/pipeline-structure {:home-dir "/tmp/moinsen" :artifacts-path-context artifacts-path-context :name "ARTIFACT PIPELINE"})]
 
     (reset! current-pipeline simple-pipeline)

--- a/backend/test/lambdaui/testpipeline/long_running.clj
+++ b/backend/test/lambdaui/testpipeline/long_running.clj
@@ -1,17 +1,16 @@
 (ns lambdaui.testpipeline.long-running
   (:use [compojure.core])
-  (:require [lambdacd.steps.shell :as shell]
-            [lambdacd.steps.manualtrigger :refer [wait-for-manual-trigger]]
-            [lambdacd.steps.control-flow :refer [either with-workspace in-parallel run] :as step]
-            [lambdacd.steps.support :as support]))
+  (:require [lambdacd.steps.manualtrigger :refer [wait-for-manual-trigger]]
+            [lambdacd.steps.control-flow :refer [either with-workspace in-parallel run]]
+            [lambdacd.stepsupport.output :as output]))
 
 
 
 
 (defn long-running-step [seconds]
   (fn [_ ctx]
-    (let [printer (support/new-printer)
-          append #(support/print-to-output ctx printer %)]
+    (let [printer (output/new-printer)
+          append #(output/print-to-output ctx printer %)]
       (doseq [remaining (reverse (range 1 seconds))]
         (append (str remaining " seconds remaining.. "))
         (Thread/sleep 1000)))

--- a/backend/test/lambdaui/testpipeline/simple_pipeline.clj
+++ b/backend/test/lambdaui/testpipeline/simple_pipeline.clj
@@ -3,7 +3,8 @@
   (:require [lambdacd.steps.shell :as shell]
             [lambdacd.steps.manualtrigger :refer [wait-for-manual-trigger]]
             [lambdacd.steps.control-flow :refer [either with-workspace in-parallel run] :as step]
-            [lambdacd.steps.support :refer [capture-output]]))
+            [lambdacd.stepsupport.output :refer [capture-output]]
+            [lambdacd.stepsupport.output :as output]))
 
 
 
@@ -31,8 +32,8 @@
 
 
 (defn long-running [_ ctx]
-  (let [p  (lambdacd.steps.support/new-printer)]
-    (lambdacd.steps.support/print-to-output ctx p "Waiting for 20 seconds before step finishes..."))
+  (let [p  (output/new-printer)]
+    (output/print-to-output ctx p "Waiting for 20 seconds before step finishes..."))
 
   (Thread/sleep (* 20 1000))
   {:status :success})

--- a/backend/test/lambdaui/testpipeline/trigger_pipeline.clj
+++ b/backend/test/lambdaui/testpipeline/trigger_pipeline.clj
@@ -3,7 +3,7 @@
   (:require [lambdacd.steps.shell :as shell]
             [lambdacd.steps.manualtrigger :refer [wait-for-manual-trigger] :as triggers]
             [lambdacd.steps.control-flow :refer [either with-workspace in-parallel run] :as step]
-            [lambdacd.steps.support :refer [capture-output]]
+            [lambdacd.stepsupport.output :refer [capture-output]]
 
             ))
 

--- a/example-pipeline/src/lambdaui/example/simple_pipeline.clj
+++ b/example-pipeline/src/lambdaui/example/simple_pipeline.clj
@@ -9,7 +9,7 @@
             [lambdaui.core :as ui]
             [lambdacd.steps.manualtrigger :refer [wait-for-manual-trigger parameterized-trigger]]
             [lambdacd.runners :as pipeline-runners]
-            [lambdacd.steps.support :as support])
+            [lambdacd.stepsupport.output :as output])
   (:import (java.nio.file.attribute FileAttribute)
            (java.nio.file Files)))
 
@@ -36,8 +36,8 @@
   {:status (swap! lastStatus swapStatus)})
 
 (defn output-parameters [args ctx]
-  (let [p (support/new-printer)
-        out #(support/print-to-output ctx p %)
+  (let [p (output/new-printer)
+        out #(output/print-to-output ctx p %)
         revision (get args :revision)
 
         ]

--- a/example-pipeline/src/lambdaui/example/simple_pipeline.clj
+++ b/example-pipeline/src/lambdaui/example/simple_pipeline.clj
@@ -6,11 +6,12 @@
             [lambdacd.core :as lambdacd]
             [org.httpkit.server :as server]
             [lambdacd.ui.api]
-            [lambdacd.util :as file-util]
             [lambdaui.core :as ui]
             [lambdacd.steps.manualtrigger :refer [wait-for-manual-trigger parameterized-trigger]]
             [lambdacd.runners :as pipeline-runners]
-            [lambdacd.steps.support :as support]))
+            [lambdacd.steps.support :as support])
+  (:import (java.nio.file.attribute FileAttribute)
+           (java.nio.file Files)))
 
 (defonce lastStatus (atom nil))
 
@@ -91,8 +92,11 @@
 
 (defonce server (atom nil))
 
+(defn- create-temp-dir []
+  (str (Files/createTempDirectory "lambdacd" (into-array FileAttribute []))))
+
 (defn -main [& args]
-  (let [home-dir (file-util/create-temp-dir)
+  (let [home-dir (create-temp-dir)
         config {:home-dir  home-dir
                 :name      "Example Pipeline"
                 :ui-config {


### PR DESCRIPTION
LambdaCD version [0.14.0](https://github.com/flosell/lambdacd/releases/tag/0.14.0) removes all deprecated APIs. Since lambda-ui still uses a couple of those, it's currently not compatible with the most recent version of LambdaCD. 

This PR removes usage of those deprecated LambdaCD APIs to make lambda-ui work with LambdaCD 0.14.0