### PR TITLE
Add waiting logic to make parameterized-trigger-test more robust

### DIFF
--- a/backend/test/lambdaui/test_utils.clj
+++ b/backend/test/lambdaui/test_utils.clj
@@ -1,6 +1,7 @@
 (ns lambdaui.test-utils
   (:import (java.nio.file.attribute FileAttribute)
-           (java.nio.file Files)))
+           (java.nio.file Files)
+           (java.util.concurrent TimeoutException)))
 
 (defn- no-file-attributes []
   (into-array FileAttribute []))
@@ -9,3 +10,16 @@
 
 (defn create-temp-dir []
    (str (Files/createTempDirectory temp-prefix (no-file-attributes))))
+
+(defn wait-for
+  "executes `f` until `predicate` on `f`'s result is true, then return the result"
+  [f predicate]
+  (loop [time-slept 0]
+    (if (> time-slept 10000)
+      (throw (TimeoutException. "waited for too long")))
+    (let [result (f)]
+      (if (not (predicate result))
+        (do
+          (Thread/sleep 50)
+          (recur (+ time-slept 50)))
+        result))))


### PR DESCRIPTION
`parameterized-trigger-test` seems to be flaky because sometimes, it runs before the trigger is fully ready. 
This PR adds a helper function that waits until the step is waiting, therefore indicating that the trigger is now in the state the test expects it to be. 