### PR TITLE
Update lein-script to 2.8.1 to make builds work in more recent java versions

### DIFF
--- a/backend/lein
+++ b/backend/lein
@@ -4,12 +4,17 @@
 # somewhere on your $PATH, like ~/bin. The rest of Leiningen will be
 # installed upon first run into the ~/.lein/self-installs directory.
 
-export LEIN_VERSION="2.7.0"
+export LEIN_VERSION="2.8.1"
 
 case $LEIN_VERSION in
     *SNAPSHOT) SNAPSHOT="YES" ;;
     *) SNAPSHOT="NO" ;;
 esac
+
+if [[ "$CLASSPATH" != "" ]]; then
+    echo "WARNING: You have \$CLASSPATH set, probably by accident."
+    echo "It is strongly recommended to unset this before proceeding."
+fi
 
 if [[ "$OSTYPE" == "cygwin" ]] || [[ "$OSTYPE" == "msys" ]]; then
     delimiter=";"
@@ -24,7 +29,7 @@ else
 fi
 
 function command_not_found {
-    >&2 echo "Leiningen coundn't find $1 in your \$PATH ($PATH), which is required."
+    >&2 echo "Leiningen couldn't find $1 in your \$PATH ($PATH), which is required."
     exit 1
 }
 
@@ -83,25 +88,6 @@ function self_install {
   fi
 }
 
-function check_root {
-  local -i user_id
-  # Thank you for the complexity, Solaris
-  if [ `uname` = "SunOS" -a -x /usr/xpg4/bin/id ]; then
-    user_id=$(/usr/xpg4/bin/id -u 2>/dev/null || echo 0)
-  else
-    user_id=$(id -u 2>/dev/null || echo 0)
-  fi
-  [ $user_id -eq 0 -a "$LEIN_ROOT" = "" ] && return 0
-  return 1
-}
-
-if check_root; then
-    echo "WARNING: You're currently running as root; probably by accident."
-    echo "Press control-C to abort or Enter to continue as root."
-    echo "Set LEIN_ROOT to disable this warning."
-    read _
-fi
-
 NOT_FOUND=1
 ORIGINAL_PWD="$PWD"
 while [ ! -r "$PWD/project.clj" ] && [ "$PWD" != "/" ] && [ $NOT_FOUND -ne 0 ]
@@ -150,7 +136,7 @@ done
 
 BIN_DIR="$(dirname "$SCRIPT")"
 
-export LEIN_JVM_OPTS="${LEIN_JVM_OPTS-"-XX:+TieredCompilation -XX:TieredStopAtLevel=1"}"
+export LEIN_JVM_OPTS="${LEIN_JVM_OPTS-"-Xverify:none -XX:+TieredCompilation -XX:TieredStopAtLevel=1"}"
 
 # This needs to be defined before we call HTTP_CLIENT below
 if [ "$HTTP_CLIENT" = "" ]; then
@@ -215,7 +201,9 @@ if [ -r "$BIN_DIR/../src/leiningen/version.clj" ]; then
 else # Not running from a checkout
     add_path CLASSPATH "$LEIN_JAR"
 
-    BOOTCLASSPATH="-Xbootclasspath/a:$LEIN_JAR"
+    if [ "$LEIN_USE_BOOTCLASSPATH" != "" ]; then
+        LEIN_JVM_OPTS="-Xbootclasspath/a:$LEIN_JAR $LEIN_JVM_OPTS"
+    fi
 
     if [ ! -r "$LEIN_JAR" -a "$1" != "self-install" ]; then
         self_install
@@ -224,7 +212,7 @@ fi
 
 if [ ! -x "$JAVA_CMD" ] && ! type -f java >/dev/null
 then
-    >&2 echo "Leiningen coundn't find 'java' executable, which is required."
+    >&2 echo "Leiningen couldn't find 'java' executable, which is required."
     >&2 echo "Please either set JAVA_CMD or put java (>=1.6) in your \$PATH ($PATH)."
     exit 1
 fi
@@ -285,7 +273,7 @@ elif [ "$1" = "upgrade" ] || [ "$1" = "downgrade" ]; then
             y|Y|"")
                 echo
                 echo "Upgrading..."
-                TARGET="/tmp/lein-$$-upgrade"
+                TARGET="/tmp/lein-${$}-upgrade"
                 if $cygwin; then
                     TARGET=$(cygpath -w "$TARGET")
                 fi
@@ -346,7 +334,7 @@ else
         else
             TRAMPOLINE_FILE="/tmp/lein-trampoline-$$"
         fi
-        trap "rm -f $TRAMPOLINE_FILE" EXIT
+        trap 'rm -f $TRAMPOLINE_FILE' EXIT
     fi
 
     if $cygwin; then
@@ -361,7 +349,6 @@ else
     else
         export TRAMPOLINE_FILE
         "$LEIN_JAVA_CMD" \
-            "${BOOTCLASSPATH[@]}" \
             -Dfile.encoding=UTF-8 \
             -Dmaven.wagon.http.ssl.easy=false \
             -Dmaven.wagon.rto=10000 \
@@ -377,11 +364,9 @@ else
           stty icanon echo > /dev/null 2>&1
         fi
 
-        ## TODO: [ -r "$TRAMPOLINE_FILE" ] may be redundant? A trampoline file
-        ## is always generated these days.
         if [ -r "$TRAMPOLINE_FILE" ] && [ "$LEIN_TRAMPOLINE_WARMUP" = "" ]; then
             TRAMPOLINE="$(cat "$TRAMPOLINE_FILE")"
-            if [ "$INPUT_CHECKSUM" = "" ]; then
+            if [ "$INPUT_CHECKSUM" = "" ]; then # not using fast trampoline
                 rm "$TRAMPOLINE_FILE"
             fi
             if [ "$TRAMPOLINE" = "" ]; then


### PR DESCRIPTION
When running leiningen commands with a newer JDK (I'm running java 10), things fail immediately: 
```
$ ./go test
Start frontend tests
[...]
Start backend tests
Exception in thread "main" java.lang.ExceptionInInitializerError
	at java.base/java.lang.Class.forName0(Native Method)
	at java.base/java.lang.Class.forName(Class.java:374)
	at clojure.lang.RT.classForName(RT.java:2168)
	at clojure.lang.RT.classForName(RT.java:2177)
	at clojure.lang.RT.loadClassForName(RT.java:2196)
	at clojure.lang.RT.load(RT.java:443)
	at clojure.lang.RT.load(RT.java:419)
	at clojure.core$load$fn__5677.invoke(core.clj:5893)
	at clojure.core$load.invokeStatic(core.clj:5892)
	at clojure.core$load.doInvoke(core.clj:5876)
	at clojure.lang.RestFn.invoke(RestFn.java:408)
	at clojure.core__init.load(Unknown Source)
	at clojure.core__init.<clinit>(Unknown Source)
	at java.base/java.lang.Class.forName0(Native Method)
	at java.base/java.lang.Class.forName(Class.java:374)
	at clojure.lang.RT.classForName(RT.java:2168)
	at clojure.lang.RT.classForName(RT.java:2177)
	at clojure.lang.RT.loadClassForName(RT.java:2196)
	at clojure.lang.RT.load(RT.java:443)
	at clojure.lang.RT.load(RT.java:419)
	at clojure.lang.RT.doInit(RT.java:461)
	at clojure.lang.RT.<clinit>(RT.java:331)
	at clojure.main.<clinit>(main.java:20)
Caused by: java.lang.ClassNotFoundException: java/sql/Timestamp
	at java.base/java.lang.Class.forName0(Native Method)
	at java.base/java.lang.Class.forName(Class.java:374)
	at clojure.lang.RT.classForName(RT.java:2168)
	at clojure.lang.RT.classForNameNonLoading(RT.java:2181)
	at clojure.instant$loading__5569__auto____6869.invoke(instant.clj:9)
	at clojure.instant__init.load(Unknown Source)
	at clojure.instant__init.<clinit>(Unknown Source)
	... 23 more
```

Seems like the Leiningen 2.7.* has some issues with those newer versions so this PR updates the packaged `lein` script to the most recent stable release. 